### PR TITLE
Code coverage enforced

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - "7"
 install:
   - npm install -g truffle
-  - npm install -g ethereumjs-testrpc
+  - npm install -g ganache-cli
   - npm install
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,14 @@
 language: node_js
 node_js:
   - "7"
+install:
+  - npm install -g truffle
+  - npm install -g ethereumjs-testrpc
+  - npm install
+script:
+  - npm test
+before_script:
+  - testrpc > /dev/null &
+  - sleep 5
+after_script:
+  - npm run coverage && cat coverage/lcov.info | coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 A DAO for a simple partnership, written in Solidity for deployment on Ethereum.
 
+It uses the Truffle framework for testing, but does not use its deployment system.
+
 # Installation
 
     $ npm install

--- a/contracts/Incomplete.sol
+++ b/contracts/Incomplete.sol
@@ -1,11 +1,26 @@
-/// Incomplete
-/// Doesn't allow anyone to deposit money
+/// Incomplete: a test contract for Partnership
+/// Doesn't allow deposits after the first time, allows proxy calls.
 pragma solidity ^0.4.18;
 contract Incomplete
 {
-	/// This executes when funds are sent to the contract
-	function() public payable {
-    require(false);
-	}
+  // The fund can only receive money once
+  bool public once;
+
+  function Incomplete() public {
+    once = true;
+  }
+
+  // Used to call Partnership.withdrawal in a failure condition
+  function run(uint value, bytes data) public {
+    require(this.call.value(value)(data));
+  }
+
+  // This executes when funds are sent to the contract
+  function() public payable {
+    require(once);
+
+    // Fail forevermore
+    once = false;
+  }
 }
 

--- a/contracts/Incomplete.sol
+++ b/contracts/Incomplete.sol
@@ -1,0 +1,11 @@
+/// Incomplete
+/// Doesn't allow anyone to deposit money
+pragma solidity ^0.4.18;
+contract Incomplete
+{
+	/// This executes when funds are sent to the contract
+	function() public payable {
+    require(false);
+	}
+}
+

--- a/contracts/Partnership.sol
+++ b/contracts/Partnership.sol
@@ -286,14 +286,11 @@ contract Partnership
 		// mark the withdrawal as successful
 		withdrawableAmounts[msg.sender] -= _amount;
 
-		// send the wei
-		if (msg.sender.send(_amount)) {
-			Withdrawal(msg.sender, _amount);
-		}
-		else {
-			// roll back if the send failed
-			withdrawableAmounts[msg.sender] += _amount;
-		}
+		// Log the withdrawal
+		Withdrawal(msg.sender, _amount);
+
+		// send the wei; if this fails the transaction fails.
+		require(msg.sender.send(_amount));
 	}
 	
 	/// Dissolve DAO and send the remaining ETH to a beneficiary

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "partnership DAO",
   "devDependencies": {
+    "coveralls": "^3.0.0",
     "solidity-coverage": "^0.4.9",
     "solium": "^1.0.9",
     "truffle": "^4.0.4"

--- a/test/Partnership.js
+++ b/test/Partnership.js
@@ -141,11 +141,14 @@ contract('Partnership', function(accounts) {
   });
 
   it('should test failed withdrawal', async function(){
+    // fund the Incomplete contract so it has some gas
+    var incomplete = await Incomplete.new();
+    await web3.eth.sendTransaction({from:creator, to:incomplete.address, value: amount});
     // create fund with two partners
     partnership = await Partnership.new([partner1, partner2], amount);
-    var incomplete = await Incomplete.new();
     await web3.eth.sendTransaction({from:partner1, to:partnership.address, value: amount});
     await web3.eth.sendTransaction({from:partner2, to:partnership.address, value: amount});
+    // propose transaction for withdrawal by Incomplete
     var callData = partnership.contract.distribute.getData(incomplete.address, distrib);
     var txn1 = await partnership.proposeTransaction(partnership.address, amount, callData, "distribute to rando", {from:partner1});
     assert(txn1.logs[0].event === 'TransactionProposed');
@@ -153,10 +156,12 @@ contract('Partnership', function(accounts) {
     // approve distribution proposal
     var confirmation = await partnership.confirmTransaction(txnId1,{from:partner2});
     assert(confirmation.logs[0].event === 'TransactionPassed');
-    // partner1 executes transaction, which fails because incomplete won't accept the funds,
-    // but doesn't throw any exceptions
+    // partner1 executes transaction, releasing funds for Incomplete
     await partnership.executeTransaction(txnId1,{from:partner1});
-    await partnership.withdraw(distrib,{from:incomplete.address});
+    // Incomplete calls partnership.withdrawal
+    var callData = partnership.contract.withdraw.getData(distrib);
+    // This fails because Incomplete rejects the send of ether
+    await expectThrow(incomplete.run(0, callData));
   });
 
   // 


### PR DESCRIPTION
* Added test scenario for failed `Partnership.withdraw()` and a new test contract `Incomplete`
* Changed Partnership.withdraw() to use `require` and revert on failure, as `send` doesn't return failure reliably (or at all).
* Set up solidity-coverage
* Set up Travis to run code coverage
* Use coveralls.io
